### PR TITLE
♻️refactor(hig): CupertinoLiquidButton 상태 변경 대응 및 테스트 스크린 업데이트

### DIFF
--- a/example/composeApp/src/commonMain/kotlin/App.kt
+++ b/example/composeApp/src/commonMain/kotlin/App.kt
@@ -59,11 +59,11 @@ fun App() {
                 lightAccent else darkAccent,
             useDarkTheme = isDark
         ) {
-//            TestScreen()
-            RootNavigationGraph(
-                backStack = backStack,
-                viewModel = viewModel
-            )
+            TestScreen()
+//            RootNavigationGraph(
+//                backStack = backStack,
+//                viewModel = viewModel
+//            )
         }
     }
 }

--- a/example/composeApp/src/commonMain/kotlin/test/TestScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/test/TestScreen.kt
@@ -18,12 +18,17 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Accessibility
 import androidx.compose.material3.Icon
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -33,10 +38,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.backdrops.layerBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import zone.ien.hig.CupertinoIcon
 import zone.ien.hig.CupertinoLargeFloatingActionButton
 import zone.ien.hig.CupertinoLiquidButton
+import zone.ien.hig.CupertinoLiquidButtonDefaults
 import zone.ien.hig.CupertinoLiquidIconButton
 import zone.ien.hig.CupertinoMediumFloatingActionButton
 import zone.ien.hig.CupertinoNavigationTitle
@@ -45,6 +52,8 @@ import zone.ien.hig.CupertinoSmallFloatingActionButton
 import zone.ien.hig.CupertinoText
 import zone.ien.hig.CupertinoTopAppBar
 import zone.ien.hig.ExperimentalCupertinoApi
+import zone.ien.hig.adaptive.AdaptiveSwitch
+import zone.ien.hig.adaptive.ExperimentalAdaptiveApi
 import zone.ien.hig.adaptive.icons.AdaptiveIcons
 import zone.ien.hig.composeapp.generated.resources.Res
 import zone.ien.hig.composeapp.generated.resources.img_calib_test2
@@ -54,15 +63,19 @@ import zone.ien.hig.icons.outlined.ChevronBackward
 import zone.ien.hig.icons.outlined.MoonStars
 import zone.ien.hig.icons.outlined.SunMax
 
-@OptIn(ExperimentalCupertinoApi::class)
+@OptIn(ExperimentalCupertinoApi::class, ExperimentalAdaptiveApi::class)
 @Composable
 fun TestScreen(
     modifier: Modifier = Modifier
 ) {
     val backdrop = rememberLayerBackdrop()
     val scrollState = rememberScrollState()
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarState = remember { SnackbarHostState() }
+    var enabled by remember { mutableStateOf(false) }
 
     CupertinoScaffold(
+        snackbarHost = { SnackbarHost(snackbarState) },
         topBar = {
             CupertinoTopAppBar(
 //                isBackgroundGradient = true,
@@ -119,7 +132,6 @@ fun TestScreen(
                 .layerBackdrop(backdrop)
                 .verticalScroll(scrollState)
                 .padding(it)
-                .background(Color.Red.copy(0.7f))
         ) {
             CupertinoNavigationTitle {
                 Text(
@@ -134,6 +146,30 @@ fun TestScreen(
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxWidth()
             )
+
+            Row {
+                AdaptiveSwitch(
+                    checked = enabled,
+                    onCheckedChange = { enabled = it }
+                )
+                CupertinoLiquidButton(
+                    onClick = { coroutineScope.launch { snackbarState.showSnackbar("clicked") } },
+                    backdrop = rememberLayerBackdrop(),
+                    colors = CupertinoLiquidButtonDefaults.glassProminentButtonColors(),
+                    enabled = enabled
+                ) {
+                    Text(text = "button")
+                }
+                CupertinoLiquidButton(
+                    onClick = { coroutineScope.launch { snackbarState.showSnackbar("clicked") } },
+                    backdrop = rememberLayerBackdrop(),
+                    colors = CupertinoLiquidButtonDefaults.glassProminentButtonColors(),
+                    enabled = !enabled
+                ) {
+                    Text(text = "button")
+                }
+            }
+
             Text(
                 text = "Hello World",
                 modifier = Modifier
@@ -155,79 +191,6 @@ fun TestScreen(
             )
         }
     }
-//     */
-    /*
-    CupertinoScaffold(
-        topBar = {
-            CupertinoLiquidTopAppBar(
-                title = {},
-                navigationIcon = {},
-                backdrop = backdrop,
-//                isTranslucent = true,
-//                isTransparent = true,
-
-            )
-        },
-        modifier = modifier
-    ) {
-        Column(
-            modifier = Modifier
-                .padding(it)
-                .verticalScroll(rememberScrollState())
-                .layerBackdrop(backdrop)
-        ) {
-            Text(
-                text = "Hello World"
-            )
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(1000.dp)
-            )
-        }
-        /*
-        Box(
-            modifier = Modifier.padding(it)
-        ) {
-            var offsetX by remember { mutableStateOf(0.dp) }
-            var offsetY by remember { mutableStateOf(0.dp) }
-            val density = LocalDensity.current
-
-            Image(
-                painter = painterResource(Res.drawable.img_calib_test),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .layerBackdrop(backdrop)
-                    .offset(offsetX, offsetY)
-                    .pointerInput(Unit) {
-                        detectTransformGestures { centroid, pan, gestureZoom, gestureRotate ->
-                            val targetX = pan.x
-                            val targetY = pan.y
-
-                            offsetX = with (density) { targetX.toDp() } + offsetX
-                            offsetY = with (density) { targetY.toDp() } + offsetY
-                        }
-                    }
-                    .fillMaxSize()
-            )
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier.fillMaxSize()
-            ) {
-                CupertinoLiquidButton(
-                    onClick = {},
-                    backdrop = backdrop
-                ) {
-                    Text(text = "Hello")
-                }
-            }
-        }
-
-         */
-    }
-
-     */
 }
 
 @Preview(showBackground = true)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.0.0"
 kotlin = "2.3.10"
-lib-version-name = "0.1.1-alpha02"
+lib-version-name = "0.1.1-alpha03"
 
 # plugin
 compose-plugin = "1.10.1"

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoLiquidButton.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoLiquidButton.kt
@@ -1,5 +1,6 @@
 package zone.ien.hig
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.Animatable as ColorAnimatable
 import androidx.compose.animation.core.Animatable as FloatAnimatable
 import androidx.compose.animation.core.tween
@@ -106,10 +107,11 @@ fun CupertinoLiquidButton(
     val isLightTheme = !isSystemInDarkTheme()
     val graphicsLayer = rememberGraphicsLayer()
 
-    val luminanceAnimation = remember { FloatAnimatable(if (isLightTheme) 1f else 0f) }
-    val tintColorAnimation = remember { ColorAnimatable(if (isLightTheme) lightTintColor else darkTintColor) }
-    val surfaceColorAnimation = remember { ColorAnimatable(if (isLightTheme) lightSurfaceColor else darkSurfaceColor) }
-    val contentColorAnimation = remember { ColorAnimatable(if (isLightTheme) lightContentColor else darkContentColor) }
+    val luminanceAnimation = remember(enabled) { FloatAnimatable(if (isLightTheme) 1f else 0f) }
+
+    val tintColorAnimation = remember(enabled) { ColorAnimatable(if (isLightTheme) lightTintColor else darkTintColor) }
+    val surfaceColorAnimation = remember(enabled) { ColorAnimatable(if (isLightTheme) lightSurfaceColor else darkSurfaceColor) }
+    val contentColorAnimation = remember(enabled) { ColorAnimatable(if (isLightTheme) lightContentColor else darkContentColor) }
 
     if (isBackgroundAdaptive) {
         val defaultColor = CupertinoTheme.colorScheme.systemBackground


### PR DESCRIPTION
- `CupertinoLiquidButton`의 애니메이션 변수(`luminanceAnimation`, `tintColorAnimation` 등)가 `enabled` 상태 변화에 따라 초기화되도록 `remember(enabled)` 추가
- `TestScreen`에 `AdaptiveSwitch`를 이용한 버튼 활성화/비활성화 테스트 코드 및 `Snackbar` 기능 추가
- `App.kt`에서 테스트를 위해 `TestScreen` 호출 활성화
- 라이브러리 버전을 `0.1.1-alpha03`으로 업데이트