### PR TITLE
✨ feat(hig): CupertinoLiquidButton 상호작용 설정 추가 및 드롭다운 메뉴 최적화

### DIFF
--- a/example/composeApp/src/commonMain/kotlin/test/TestScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/test/TestScreen.kt
@@ -167,6 +167,7 @@ fun TestScreen(
                 CupertinoLiquidButton(
                     onClick = { expanded = true },
                     backdrop = rememberDefaultBackdrop(),
+                    isInteractive = false,
                     colors = CupertinoLiquidButtonDefaults.glassProminentButtonColors(),
                 ) {
                     Text(text = "Open Menu")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.0.0"
 kotlin = "2.3.10"
-lib-version-name = "0.1.1-alpha06"
+lib-version-name = "0.1.1-alpha07"
 
 # plugin
 compose-plugin = "1.10.2"

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoDropdownMenu.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoDropdownMenu.kt
@@ -182,7 +182,6 @@ fun CupertinoDropdownMenu(
                 content = { scope.run { content() } },
                 width = width,
                 paddingValue = paddingValues,
-                menuOffset = menuOffset,
                 backdrop = backdrop,
             )
         }
@@ -508,7 +507,6 @@ private fun DropdownMenuContent(
     paddingValue: PaddingValues,
     modifier: Modifier = Modifier,
     backdrop: Backdrop,
-    menuOffset: Offset,
     content: @Composable () -> Unit,
 ) {
     // Menu open/close animation.
@@ -553,9 +551,7 @@ private fun DropdownMenuContent(
         }
     }
     val shape = CupertinoDropdownMenuDefaults.Shape
-
-    val interactiveHighlight =
-        remember(animationScope) { InteractiveHighlight(animationScope = animationScope) }
+    val interactiveHighlight = remember(animationScope) { InteractiveHighlight(animationScope = animationScope) }
 
     CupertinoSurface(
         color = Color.Transparent,
@@ -604,57 +600,21 @@ private fun DropdownMenuContent(
 
                                 val maxDragScale = 4.dp.toPx() / height
                                 val offsetAngle = atan2(offset.y, offset.x)
-                                scaleX =
-                                    scale + maxDragScale * abs(cos(offsetAngle) * offset.x / this.size.maxDimension) * (width / height).fastCoerceAtMost(
-                                        1f
-                                    )
-                                scaleY =
-                                    scale + maxDragScale * abs(sin(offsetAngle) * offset.y / this.size.maxDimension) * (height / width).fastCoerceAtMost(
-                                        1f
-                                    )
+
+                                scaleX = scale + maxDragScale * abs(cos(offsetAngle) * offset.x / this.size.maxDimension) * (width / height).fastCoerceAtMost(1f)
+                                scaleY = scale + maxDragScale * abs(sin(offsetAngle) * offset.y / this.size.maxDimension) * (height / width).fastCoerceAtMost(1f)
                             },
                             onDrawSurface = {
                                 drawRect(containerColor.copy(alpha = 0.95f))
                             },
-                            onDrawBackdrop = { drawBackdrop ->
-                                this.center
-                                this.size
-                                translate(
-//                                        left = -menuOffset.x,
-//                                        top = -menuOffset.y
-                                ) {
-                                    drawBackdrop()
-                                }
-                            }
                         )
                         .fillMaxWidth()
                         .heightIn(max = MenuMaxHeight)
                         .verticalScroll(scrollState),
                 ) { constraints ->
                     val layoutWidth = constraints.maxWidth
-                    val itemPlaceables =
-                        subcompose(CupertinoDropdownMenuSlots.Item, content).fastMap {
-                            it.measure(constraints)
-                        }
-
-                    val dividerHeightPx = DividerHeight.toPx()
-
-//                    fun dividerPlaceable(idx: Int) =
-//                        subcompose(idx) { CupertinoHorizontalDivider() }.first()
-//                            .measure(constraints)
-
-                    val allPlacements = buildList(itemPlaceables.size * 2) {
-                        itemPlaceables.fastForEachIndexed { index, placeable ->
-                            add(placeable)
-                            if (index != itemPlaceables.lastIndex &&
-                                placeable.height > dividerHeightPx &&
-                                itemPlaceables[index + 1].height > dividerHeightPx
-                            ) {
-//                                add(dividerPlaceable(index))
-                            }
-                        }
-                    }
-
+                    val itemPlaceables = subcompose(CupertinoDropdownMenuSlots.Item, content).fastMap { it.measure(constraints) }
+                    val allPlacements = buildList(itemPlaceables.size * 2) { itemPlaceables.fastForEach { placeable -> add(placeable) } }
                     val height = allPlacements.fastSumBy { it.height }
 
                     layout(layoutWidth, height) {

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoLiquidButton.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoLiquidButton.kt
@@ -1,10 +1,6 @@
 package zone.ien.hig
 
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.Animatable as ColorAnimatable
-import androidx.compose.animation.core.Animatable as FloatAnimatable
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -34,7 +30,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.rememberGraphicsLayer
@@ -46,19 +41,13 @@ import androidx.compose.ui.util.lerp
 import com.kyant.backdrop.Backdrop
 import com.kyant.backdrop.drawBackdrop
 import com.kyant.backdrop.effects.blur
-import com.kyant.backdrop.effects.colorControls
 import com.kyant.backdrop.effects.lens
 import com.kyant.backdrop.effects.vibrancy
 import com.kyant.shapes.RoundedRectangularShape
-import com.kyant.shapes.UnevenRoundedRectangle
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import zone.ien.hig.CupertinoButtonDefaults.plainButtonColors
 import zone.ien.hig.CupertinoLiquidButtonDefaults.glassButtonColors
-import zone.ien.hig.CupertinoLiquidButtonDefaults.glassProminentButtonColors
 import zone.ien.hig.theme.CupertinoTheme
 import zone.ien.hig.theme.darkColorScheme
 import zone.ien.hig.theme.lightColorScheme
@@ -69,6 +58,8 @@ import kotlin.math.cos
 import kotlin.math.sign
 import kotlin.math.sin
 import kotlin.math.tanh
+import androidx.compose.animation.Animatable as ColorAnimatable
+import androidx.compose.animation.core.Animatable as FloatAnimatable
 
 @Composable
 @ExperimentalCupertinoApi
@@ -83,6 +74,7 @@ fun CupertinoLiquidButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     backdrop: Backdrop,
     isBackgroundAdaptive: Boolean = true,
+    isInteractive: Boolean = true,
     content: @Composable RowScope.() -> Unit
 ) {
     val animationScope = rememberCoroutineScope()
@@ -104,7 +96,6 @@ fun CupertinoLiquidButton(
     val graphicsLayer = rememberGraphicsLayer()
 
     val luminanceAnimation = remember(enabled) { FloatAnimatable(if (isLightTheme) 1f else 0f) }
-
     val tintColorAnimation = remember(enabled) { ColorAnimatable(if (isLightTheme) lightTintColor else darkTintColor) }
     val surfaceColorAnimation = remember(enabled) { ColorAnimatable(if (isLightTheme) lightSurfaceColor else darkSurfaceColor) }
     val contentColorAnimation = remember(enabled) { ColorAnimatable(if (isLightTheme) lightContentColor else darkContentColor) }
@@ -158,7 +149,7 @@ fun CupertinoLiquidButton(
                         lens(12.dp.toPx(), 24.dp.toPx())
                     }
                 },
-                layerBlock = if (enabled) {
+                layerBlock = if (enabled && isInteractive) {
                     {
                         val width = this.size.width
                         val height = this.size.height
@@ -169,13 +160,16 @@ fun CupertinoLiquidButton(
                         val maxOffset = this.size.minDimension
                         val initialDerivative = 0.05f
                         val offset = interactiveHighlight.offset
+
                         translationX = maxOffset * tanh(initialDerivative * offset.x / maxOffset)
                         translationY = maxOffset * tanh(initialDerivative * offset.y / maxOffset)
 
                         val maxDragScale = 4.dp.toPx() / height
                         val offsetAngle = atan2(offset.y, offset.x)
+
                         scaleX = scale + maxDragScale * abs(cos(offsetAngle) * offset.x / this.size.maxDimension) * (width / height).fastCoerceAtMost(1f)
                         scaleY = scale + maxDragScale * abs(sin(offsetAngle) * offset.y / this.size.maxDimension) * (height / width).fastCoerceAtMost(1f)
+
                     }
                 } else {
                     null
@@ -244,6 +238,7 @@ fun CupertinoLiquidIconButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     backdrop: Backdrop,
     isBackgroundAdaptive: Boolean = true,
+    isInteractive: Boolean = true,
     content: @Composable () -> Unit
 ) {
     CupertinoLiquidButton(
@@ -257,6 +252,7 @@ fun CupertinoLiquidIconButton(
         contentPadding = PaddingValues(8.dp),
         backdrop = backdrop,
         isBackgroundAdaptive = isBackgroundAdaptive,
+        isInteractive = isInteractive,
         content = {
             Box(
                 modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
- `CupertinoLiquidButton`에 `isInteractive` 파라미터를 추가하여 상호작용 애니메이션 활성화 여부 제어 가능
- `CupertinoDropdownMenu`의 불필요한 `menuOffset` 매개변수 및 사용되지 않는 드롭다운 배경 그리기 로직 제거
- `CupertinoDropdownMenu` 내의 불필요한 레이아웃 측정 및 리스트 생성 로직을 단순화하여 성능 최적화
- `TestScreen`에서 메뉴 오픈 버튼의 `isInteractive`를 `false`로 설정
- 라이브러리 버전을 `0.1.1-alpha07`로 업데이트 및 미사용 import 제거

Closes #58