### PR TITLE
✨ feat(hig): CupertinoDropdownMenu 아이콘 파라미터 변경 및 레이아웃 개선

### DIFF
--- a/example/composeApp/src/commonMain/kotlin/cupertino/CupertinoWidgetsScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/cupertino/CupertinoWidgetsScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Badge
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -1796,10 +1797,11 @@ private fun DropdownExample(
                     }
                 ) {
                     MenuAction(
+                        enabled = false,
                         onClick = {
                             dropdownVisible = false
                         },
-                        icon = {
+                        leadingIcon = {
                             CupertinoIcon(
                                 imageVector = CupertinoIcons.Default.SquareAndArrowUp,
                                 contentDescription = null
@@ -1809,15 +1811,17 @@ private fun DropdownExample(
                         CupertinoText("Share")
                     }
                     MenuAction(
-                        enabled = false,
                         onClick = {
                             dropdownVisible = false
                         },
-                        icon = {
+                        leadingIcon = {
                             CupertinoIcon(
                                 imageVector = CupertinoIcons.Default.Bookmark,
                                 contentDescription = null
                             )
+                        },
+                        trailingIcon = {
+                            Badge { Text("1") }
                         }
                     ) {
                         CupertinoText("Add to Favorites")
@@ -1830,7 +1834,7 @@ private fun DropdownExample(
 
                     },
                     contentColor = red,
-                    icon = {
+                    leadingIcon = {
                         CupertinoIcon(
                             imageVector = CupertinoIcons.Default.Trash,
                             contentDescription = null
@@ -1880,7 +1884,7 @@ private fun DropdownExample2(
                         onClick = {
                             dropdownVisible = false
                         },
-                        icon = {
+                        leadingIcon = {
                             CupertinoIcon(
                                 imageVector = CupertinoIcons.Default.SquareAndArrowUp,
                                 contentDescription = null
@@ -1894,7 +1898,7 @@ private fun DropdownExample2(
                         onClick = {
                             dropdownVisible = false
                         },
-                        icon = {
+                        leadingIcon = {
                             CupertinoIcon(
                                 imageVector = CupertinoIcons.Default.Bookmark,
                                 contentDescription = null
@@ -1911,7 +1915,7 @@ private fun DropdownExample2(
 
                     },
                     contentColor = red,
-                    icon = {
+                    leadingIcon = {
                         CupertinoIcon(
                             imageVector = CupertinoIcons.Default.Trash,
                             contentDescription = null

--- a/example/composeApp/src/commonMain/kotlin/test/TestScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/test/TestScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.backdrops.layerBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
@@ -218,7 +217,7 @@ fun TestScreen(
                     ) {
                         MenuAction(
                             onClick = { expanded = false },
-                            icon = {
+                            leadingIcon = {
                                 CupertinoIcon(
                                     imageVector = CupertinoIcons.Default.CheckmarkCircle,
                                     contentDescription = null
@@ -229,7 +228,7 @@ fun TestScreen(
                         }
                         MenuAction(
                             onClick = { expanded = false },
-                            icon = {
+                            leadingIcon = {
                                 CupertinoIcon(
                                     imageVector = CupertinoIcons.Default.Pin,
                                     contentDescription = null
@@ -240,7 +239,7 @@ fun TestScreen(
                         }
                         MenuAction(
                             onClick = { expanded = false },
-                            icon = {
+                            leadingIcon = {
                                 CupertinoIcon(
                                     imageVector = CupertinoIcons.Default.PersonCropCircle,
                                     contentDescription = null

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.0.0"
 kotlin = "2.3.20"
-lib-version-name = "1.0.2-alpha01"
+lib-version-name = "1.0.2-alpha02"
 
 # plugin
 compose-plugin = "1.10.3"

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoDropdownMenu.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoDropdownMenu.kt
@@ -58,11 +58,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.TransformOrigin
-import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.layout.SubcomposeLayout
@@ -82,7 +80,6 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastCoerceAtMost
 import androidx.compose.ui.util.fastForEach
-import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.util.fastSumBy
 import androidx.compose.ui.util.lerp
@@ -144,12 +141,9 @@ fun CupertinoDropdownMenu(
     val expandedStates = remember { MutableTransitionState(false) }
     expandedStates.targetState = expanded
     val safePadding = 32.dp
-//    val density = LocalDensity.current
-//    val safePaddingPx = with(density) { safePadding.roundToPx() }
 
     if (expandedStates.currentState || expandedStates.targetState) {
         var transformOrigin by remember { mutableStateOf(TransformOrigin.Center) }
-//        var menuOffset by remember { mutableStateOf(Offset.Zero) }
         val density = LocalDensity.current
         val popupPositionProvider = DropdownMenuPositionProvider(
             contentOffset = offset,
@@ -158,10 +152,6 @@ fun CupertinoDropdownMenu(
             density = density
         ) { parentBounds, menuBounds ->
             transformOrigin = calculateTransformOrigin(parentBounds, menuBounds)
-//            menuOffset = Offset(
-//                menuBounds.left.toFloat() + safePaddingPx,
-//                menuBounds.top.toFloat() + safePaddingPx
-//            )
         }
 
         Popup(
@@ -279,8 +269,7 @@ fun CupertinoMenuScope.MenuTitle(
  * @param onClickLabel semantics label for the [onClick] action. Should be the same text as in [title]
  * @param contentColor color of the item contend.
  * Usually [CupertinoColors.systemRed] is used for destructive actions.
- * @param icon action trailing icon
- * @param caption content before [icon]
+ * @param leadingIcon action leading icon
  * @param title action title
  * */
 @Composable
@@ -290,8 +279,8 @@ fun CupertinoMenuScope.MenuAction(
     onClickLabel: String? = null,
     enabled: Boolean = true,
     contentColor: Color = CupertinoDropdownMenuDefaults.ContentColor,
-    icon: (@Composable () -> Unit) = {},
-    caption: @Composable () -> Unit = {},
+    leadingIcon: @Composable () -> Unit = {},
+    trailingIcon: @Composable () -> Unit = {},
     title: @Composable () -> Unit,
 ) = ActionWithoutPadding(
     onClickLabel = onClickLabel,
@@ -299,8 +288,8 @@ fun CupertinoMenuScope.MenuAction(
     onClick = onClick,
     enabled = enabled,
     contentColor = contentColor,
-    icon = icon,
-    caption = caption,
+    leadingIcon = leadingIcon,
+    trailingIcon = trailingIcon,
 )
 {
     Box(
@@ -322,8 +311,7 @@ fun CupertinoMenuScope.MenuAction(
  * @param onClickLabel semantics label for the [onClick] action. Should be the same text as in [title]
  * @param contentColor color of the item contend.
  * Usually [CupertinoColors.systemRed] is used for destructive actions.
- * @param icon action trailing icon
- * @param caption content before [icon]
+ * @param leadingIcon action leading icon
  * @param title action title
  * */
 @Composable
@@ -335,8 +323,8 @@ fun CupertinoMenuScope.MenuPickerAction(
     enabled: Boolean = true,
     contentColor: Color = CupertinoDropdownMenuDefaults.ContentColor,
     selectionIcon: (@Composable () -> Unit) = { CupertinoDropdownMenuDefaults.PickerLeadingIcon() },
-    icon: (@Composable () -> Unit) = {},
-    caption: @Composable () -> Unit = {},
+    leadingIcon: (@Composable () -> Unit) = {},
+    trailingIcon: @Composable () -> Unit = {},
     title: @Composable () -> Unit,
 ) {
     this as CupertinoMenuScopeImpl
@@ -358,8 +346,8 @@ fun CupertinoMenuScope.MenuPickerAction(
         onClick = onClick,
         enabled = enabled,
         contentColor = contentColor,
-        icon = icon,
-        caption = caption,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
         title = { pv ->
             Box(
                 contentAlignment = Alignment.CenterStart,
@@ -410,8 +398,8 @@ private fun CupertinoMenuScope.ActionWithoutPadding(
     onClickLabel: String? = null,
     enabled: Boolean = true,
     contentColor: Color = Color.Unspecified,
-    icon: @Composable () -> Unit = {},
-    caption: @Composable () -> Unit = {},
+    leadingIcon: @Composable () -> Unit = {},
+    trailingIcon: @Composable () -> Unit = {},
     title: @Composable (PaddingValues) -> Unit,
 ) = MenuItem {
     val color = contentColor.takeOrElse { LocalContentColor.current }.let { if (enabled) it else it.copy(alpha = it.alpha / 4f) }
@@ -423,7 +411,7 @@ private fun CupertinoMenuScope.ActionWithoutPadding(
             modifier = modifier
                 .heightIn(min = CupertinoSectionTokens.MinHeight)
                 .fillMaxWidth()
-                .padding(8.dp)
+                .padding(horizontal = 8.dp)
                 .clip(RoundedRectangle(24.dp))
                 .clickable(
                     enabled = enabled,
@@ -438,16 +426,24 @@ private fun CupertinoMenuScope.ActionWithoutPadding(
                     horizontalArrangement = Arrangement.spacedBy(CupertinoSectionTokens.SplitPadding),
                     modifier = Modifier.padding(it.copy(end = 0.dp))
                 ) {
-                    caption.invoke()
-
                     Box(
                         contentAlignment = Alignment.Center,
-                        modifier = Modifier.size(MinItemHeight / 3),
+                        modifier = Modifier.size(MinItemHeight / 2),
                     ) {
-                        icon.invoke()
+                        leadingIcon.invoke()
+                    }
+                    Box(
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        title(it.copy(start = 0.dp))
+                    }
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier.size(MinItemHeight / 2),
+                    ) {
+                        trailingIcon.invoke()
                     }
                 }
-                title(it.copy(start = 0.dp))
             }
         }
     }
@@ -607,6 +603,7 @@ private fun DropdownMenuContent(
                             },
                         )
                         .fillMaxWidth()
+                        .padding(vertical = 8.dp)
                         .heightIn(max = MenuMaxHeight)
                         .verticalScroll(scrollState),
                 ) { constraints ->


### PR DESCRIPTION
CupertinoDropdownMenu의 `MenuAction` 파라미터에서 기존 `icon`, `caption`을 `leadingIcon`, `trailingIcon`으로 변경하고 전반적인 레이아웃을 개선했습니다.

- `MenuAction` 파라미터 이름을 `leadingIcon`으로 변경하고 `trailingIcon` 추가
- 메뉴 아이템 내 아이콘 크기를 조정하고 텍스트 영역에 `weight(1f)` 적용
- `CupertinoDropdownMenu` 내부에 수직 패딩 및 아이템 가로 패딩 수정
- 불필요한 미사용 코드 및 주석 제거
- 라이브러리 버전을 `1.0.2-alpha02`로 업데이트
- 샘플 앱(`CupertinoWidgetsScreen`, `TestScreen`)에 변경된 파라미터 반영 및 테스트 코드 추가