### PR TITLE
의존성 대규모 업데이트 및 Capsule 라이브러리 Shapes API 마이그레이션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ xcuserdata
 .kotlin/
 **/.kotlin/
 /.kotlin/
+gpg_private.asc
+public_key.asc

--- a/example/androidApp/src/main/kotlin/zone/ien/hig/example/MainActivity.kt
+++ b/example/androidApp/src/main/kotlin/zone/ien/hig/example/MainActivity.kt
@@ -19,16 +19,12 @@
 package zone.ien.hig.example
 
 import App
-import RootViewModel
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import koinInitialize
 import org.koin.core.context.GlobalContext
-import org.koin.core.context.startKoin
-import org.koin.core.module.dsl.viewModel
-import org.koin.dsl.module
 
 class MainActivity: ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/example/composeApp/src/commonMain/kotlin/CupertinoOverscrollEffect.kt
+++ b/example/composeApp/src/commonMain/kotlin/CupertinoOverscrollEffect.kt
@@ -20,7 +20,11 @@
 
 @file:OptIn(ExperimentalFoundationApi::class)
 
-import androidx.compose.animation.core.*
+import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateTo
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.foundation.layout.offset
@@ -33,15 +37,13 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.Measurable
-import androidx.compose.ui.layout.MeasureResult
-import androidx.compose.ui.layout.MeasureScope
-import androidx.compose.ui.layout.OnPlacedModifier
 import androidx.compose.ui.layout.onPlaced
-import androidx.compose.ui.node.DelegatableNode
-import androidx.compose.ui.node.LayoutModifierNode
-import androidx.compose.ui.unit.*
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.unit.round
+import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.unit.toSize
 import kotlinx.coroutines.isActive
 import kotlin.coroutines.coroutineContext
 import kotlin.math.abs

--- a/example/composeApp/src/commonMain/kotlin/cupertino/CupertinoWidgetsScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/cupertino/CupertinoWidgetsScreen.kt
@@ -43,10 +43,8 @@ import RootDetails
 import RootRoute
 import RootUiState
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.AnchoredDraggableState
 import androidx.compose.foundation.gestures.ScrollableState
@@ -100,7 +98,6 @@ import androidx.navigation3.runtime.NavKey
 import com.kyant.backdrop.Backdrop
 import com.kyant.backdrop.backdrops.LayerBackdrop
 import com.kyant.backdrop.backdrops.layerBackdrop
-import zone.ien.hig.utils.rememberDefaultBackdrop
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -133,8 +130,6 @@ import zone.ien.hig.CupertinoLiquidButtonDefaults
 import zone.ien.hig.CupertinoLiquidIconButton
 import zone.ien.hig.CupertinoMenuItemData
 import zone.ien.hig.CupertinoMenuSectionData
-import zone.ien.hig.CupertinoNavigationBar
-import zone.ien.hig.CupertinoNavigationBarItem
 import zone.ien.hig.CupertinoNavigationBarItemData
 import zone.ien.hig.CupertinoNavigationTitle
 import zone.ien.hig.CupertinoPickerState
@@ -166,8 +161,6 @@ import zone.ien.hig.adaptive.ExperimentalAdaptiveApi
 import zone.ien.hig.adaptive.Theme
 import zone.ien.hig.adaptive.icons.AdaptiveIcons
 import zone.ien.hig.adaptive.icons.Add
-import zone.ien.hig.adaptive.icons.Menu
-import zone.ien.hig.adaptive.icons.Person
 import zone.ien.hig.adaptive.icons.Settings
 import zone.ien.hig.adaptive.icons.Share
 import zone.ien.hig.cancel
@@ -179,7 +172,6 @@ import zone.ien.hig.icons.filled.Archivebox
 import zone.ien.hig.icons.filled.Banknote
 import zone.ien.hig.icons.filled.Pin
 import zone.ien.hig.icons.filled.Trash
-import zone.ien.hig.icons.outlined.Book
 import zone.ien.hig.icons.outlined.Bookmark
 import zone.ien.hig.icons.outlined.FaceSmiling
 import zone.ien.hig.icons.outlined.Heart
@@ -224,6 +216,7 @@ import zone.ien.hig.theme.systemOrange
 import zone.ien.hig.theme.systemPurple
 import zone.ien.hig.theme.systemRed
 import zone.ien.hig.theme.systemYellow
+import zone.ien.hig.utils.rememberDefaultBackdrop
 import kotlin.time.Instant
 
 private enum class PickerTab {

--- a/example/composeApp/src/commonMain/kotlin/icons/IconsScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/icons/IconsScreen.kt
@@ -45,8 +45,6 @@ import com.kyant.backdrop.backdrops.layerBackdrop
 import zone.ien.hig.CupertinoAlertDialog
 import zone.ien.hig.CupertinoIcon
 import zone.ien.hig.CupertinoIconButton
-import zone.ien.hig.CupertinoLiquidIconButton
-import zone.ien.hig.CupertinoNavigateBackButton
 import zone.ien.hig.CupertinoNavigateBackLiquidButton
 import zone.ien.hig.CupertinoScaffold
 import zone.ien.hig.CupertinoSegmentedControl

--- a/example/composeApp/src/commonMain/kotlin/sections/SectionsScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/sections/SectionsScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.backdrops.layerBackdrop
 import zone.ien.hig.CupertinoDatePickerState
-import zone.ien.hig.CupertinoNavigateBackButton
 import zone.ien.hig.CupertinoNavigateBackLiquidButton
 import zone.ien.hig.CupertinoScaffold
 import zone.ien.hig.CupertinoSegmentedControl
@@ -56,7 +55,6 @@ import zone.ien.hig.MenuDivider
 import zone.ien.hig.MenuPickerAction
 import zone.ien.hig.icons.CupertinoIcons
 import zone.ien.hig.icons.outlined.Heart
-import zone.ien.hig.isTopBarTransparent
 import zone.ien.hig.rememberCupertinoDatePickerState
 import zone.ien.hig.rememberCupertinoTimePickerState
 import zone.ien.hig.section.CupertinoLinkIcon

--- a/example/composeApp/src/commonMain/kotlin/test/TestScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/test/TestScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.backdrops.layerBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
-import zone.ien.hig.utils.rememberDefaultBackdrop
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import zone.ien.hig.CupertinoDropdownMenu
@@ -45,7 +44,6 @@ import zone.ien.hig.CupertinoLiquidButton
 import zone.ien.hig.CupertinoLiquidButtonDefaults
 import zone.ien.hig.CupertinoLiquidIconButton
 import zone.ien.hig.CupertinoMenuItemData
-import zone.ien.hig.CupertinoMenuSectionData
 import zone.ien.hig.CupertinoNavigationTitle
 import zone.ien.hig.CupertinoScaffold
 import zone.ien.hig.CupertinoText
@@ -63,6 +61,7 @@ import zone.ien.hig.icons.outlined.ChevronBackward
 import zone.ien.hig.icons.outlined.PersonCropCircle
 import zone.ien.hig.icons.outlined.Pin
 import zone.ien.hig.icons.outlined.SunMax
+import zone.ien.hig.utils.rememberDefaultBackdrop
 
 @OptIn(ExperimentalCupertinoApi::class, ExperimentalAdaptiveApi::class)
 @Composable

--- a/example/composeApp/src/iosMain/kotlin/main.ios.kt
+++ b/example/composeApp/src/iosMain/kotlin/main.ios.kt
@@ -18,7 +18,6 @@
 
 
 
-import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.window.ComposeUIViewController
 import platform.UIKit.UIViewController

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,8 +33,8 @@ kotlin.apple.xcodeCompatibility.nowarn=true
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-android.compileSdk=36
-android.targetSdk=36
+android.compileSdk=37
+android.targetSdk=37
 android.minSdk=29
 
 #Jetbrains KMP

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,29 +1,29 @@
 [versions]
-agp = "9.0.0"
-kotlin = "2.3.21"
-lib-version-name = "1.1.0"
+agp = "9.1.1"
+kotlin = "2.4.10"
+lib-version-name = "1.2.0"
 
 # plugin
-compose-plugin = "1.11.0-rc01"
+compose-plugin = "1.11.1"
 compose-plugin-experimental = "1.11.0-alpha07"
 compose-navigation3 = "1.1.1"
 
 # ui
 activity-compose = "1.13.0"
-lifecycle = "2.10.0"
+lifecycle = "2.11.0"
 backdrop = "2.0.0-alpha06"
-capsule = "1.2.0"
+capsule = "2.1.4"
 haze = "1.7.2"
 
 # functionality
-datetime = "0.7.1"
-material-kolor = "4.1.1"
+datetime = "0.8.0"
+material-kolor = "5.0.0"
 
 # backend
 serialization = "1.11.0"
-vanniktech-mavenPublish = "0.36.0"
-atomicfu = "0.23.2"
-koin = "4.2.1"
+vanniktech-mavenPublish = "0.37.0"
+atomicfu = "0.33.0"
+koin = "4.2.2"
 
 [libraries]
 
@@ -46,7 +46,7 @@ compose-navigation3 = { group = "org.jetbrains.androidx.navigation3", name = "na
 backdrop = { group = "zone.ien.backdrop", name = "backdrop", version.ref = "backdrop"}
 #backdrop = { group = "io.github.kyant0", name = "backdrop", version.ref = "backdrop"}
 #capsule = { group = "io.github.kyant0", name = "shapes", version.ref = "capsule"}
-capsule = { group = "zone.ien.shapes", name = "shapes", version.ref = "capsule"}
+capsule = { group = "zone.ien.capsule", name = "capsule", version.ref = "capsule"}
 haze = { group = "dev.chrisbanes.haze", name = "haze", version.ref = "haze" }
 
 # functionality

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -19,6 +19,6 @@
 #Fri Nov 22 12:33:15 PST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hig-adaptive/src/commonMain/kotlin/zone/ien/hig/adaptive/Shapes.kt
+++ b/hig-adaptive/src/commonMain/kotlin/zone/ien/hig/adaptive/Shapes.kt
@@ -25,8 +25,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.dp
 import com.kyant.capsule.ContinuousRoundedRectangle
-import zone.ien.hig.theme.Shapes as CupertinoShapes
-import androidx.compose.material3.Shapes as MaterialShapes
 
 /**
  * A class that holds the shapes for different design systems.

--- a/hig-adaptive/src/commonMain/kotlin/zone/ien/hig/adaptive/Shapes.kt
+++ b/hig-adaptive/src/commonMain/kotlin/zone/ien/hig/adaptive/Shapes.kt
@@ -24,8 +24,7 @@ import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.dp
-import com.kyant.shapes.RoundedRectangle
-import com.kyant.shapes.UnevenRoundedRectangle
+import com.kyant.capsule.ContinuousRoundedRectangle
 import zone.ien.hig.theme.Shapes as CupertinoShapes
 import androidx.compose.material3.Shapes as MaterialShapes
 
@@ -53,11 +52,11 @@ class Shapes(
     val medium: CornerBasedShape = RoundedCornerShape(12.dp),
     val large: CornerBasedShape = RoundedCornerShape(16.dp),
     val extraLarge: CornerBasedShape = RoundedCornerShape(28.dp),
-    val higExtraSmall: RoundedRectangle = RoundedRectangle(4.dp),
-    val higSmall: RoundedRectangle = RoundedRectangle(8.dp),
-    val higMedium: RoundedRectangle = RoundedRectangle(12.dp),
-    val higLarge: RoundedRectangle = RoundedRectangle(16.dp),
-    val higExtraLarge: RoundedRectangle = RoundedRectangle(24.dp)
+    val higExtraSmall: ContinuousRoundedRectangle = ContinuousRoundedRectangle(4.dp),
+    val higSmall: ContinuousRoundedRectangle = ContinuousRoundedRectangle(8.dp),
+    val higMedium: ContinuousRoundedRectangle = ContinuousRoundedRectangle(12.dp),
+    val higLarge: ContinuousRoundedRectangle = ContinuousRoundedRectangle(16.dp),
+    val higExtraLarge: ContinuousRoundedRectangle = ContinuousRoundedRectangle(24.dp)
 ) {
     /**
      * Creates a copy of this Shapes object with the specified values replaced.
@@ -80,11 +79,11 @@ class Shapes(
         medium: CornerBasedShape = this.medium,
         large: CornerBasedShape = this.large,
         extraLarge: CornerBasedShape = this.extraLarge,
-        higExtraSmall: RoundedRectangle = this.higExtraSmall,
-        higSmall: RoundedRectangle = this.higSmall,
-        higMedium: RoundedRectangle = this.higMedium,
-        higLarge: RoundedRectangle = this.higLarge,
-        higExtraLarge: RoundedRectangle = this.higExtraLarge
+        higExtraSmall: ContinuousRoundedRectangle = this.higExtraSmall,
+        higSmall: ContinuousRoundedRectangle = this.higSmall,
+        higMedium: ContinuousRoundedRectangle = this.higMedium,
+        higLarge: ContinuousRoundedRectangle = this.higLarge,
+        higExtraLarge: ContinuousRoundedRectangle = this.higExtraLarge
     ) = Shapes(
         extraSmall = extraSmall,
         small = small,

--- a/hig-core/src/commonMain/kotlin/zone/ien/hig/theme/Shapes.kt
+++ b/hig-core/src/commonMain/kotlin/zone/ien/hig/theme/Shapes.kt
@@ -20,8 +20,6 @@
 
 package zone.ien.hig.theme
 
-import androidx.compose.foundation.shape.CornerBasedShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.staticCompositionLocalOf

--- a/hig-core/src/commonMain/kotlin/zone/ien/hig/theme/Shapes.kt
+++ b/hig-core/src/commonMain/kotlin/zone/ien/hig/theme/Shapes.kt
@@ -26,8 +26,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.dp
-import com.kyant.shapes.RoundedRectangle
-import com.kyant.shapes.UnevenRoundedRectangle
+import com.kyant.capsule.ContinuousRoundedRectangle
 import zone.ien.hig.InternalCupertinoApi
 
 /**
@@ -41,11 +40,11 @@ import zone.ien.hig.InternalCupertinoApi
  */
 @Stable
 class Shapes(
-    val extraSmall: RoundedRectangle = ShapeDefaults.ExtraSmall,
-    val small: RoundedRectangle = ShapeDefaults.Small,
-    val medium: RoundedRectangle = ShapeDefaults.Medium,
-    val large: RoundedRectangle = ShapeDefaults.Large,
-    val extraLarge: RoundedRectangle = ShapeDefaults.ExtraLarge,
+    val extraSmall: ContinuousRoundedRectangle = ShapeDefaults.ExtraSmall,
+    val small: ContinuousRoundedRectangle = ShapeDefaults.Small,
+    val medium: ContinuousRoundedRectangle = ShapeDefaults.Medium,
+    val large: ContinuousRoundedRectangle = ShapeDefaults.Large,
+    val extraLarge: ContinuousRoundedRectangle = ShapeDefaults.ExtraLarge,
 ) {
     /**
      * Creates a copy of this Shapes with the specified values replaced.
@@ -57,11 +56,11 @@ class Shapes(
      * @param extraLarge the new extra large corner shape
      */
     fun copy(
-        extraSmall: RoundedRectangle = this.extraSmall,
-        small: RoundedRectangle = this.small,
-        medium: RoundedRectangle = this.medium,
-        large: RoundedRectangle = this.large,
-        extraLarge: RoundedRectangle = this.extraLarge,
+        extraSmall: ContinuousRoundedRectangle = this.extraSmall,
+        small: ContinuousRoundedRectangle = this.small,
+        medium: ContinuousRoundedRectangle = this.medium,
+        large: ContinuousRoundedRectangle = this.large,
+        extraLarge: ContinuousRoundedRectangle = this.extraLarge,
     ) = Shapes(
         extraSmall = extraSmall,
         small = small,
@@ -80,17 +79,17 @@ val LocalShapes = staticCompositionLocalOf { Shapes() }
 @Immutable
 object ShapeDefaults {
     /** Extra small sized corner shape */
-    val ExtraSmall: RoundedRectangle = RoundedRectangle(4.dp)
+    val ExtraSmall: ContinuousRoundedRectangle = ContinuousRoundedRectangle(4.dp)
 
     /** Small sized corner shape */
-    val Small: RoundedRectangle = RoundedRectangle(8.dp)
+    val Small: ContinuousRoundedRectangle = ContinuousRoundedRectangle(8.dp)
 
     /** Medium sized corner shape */
-    val Medium: RoundedRectangle = RoundedRectangle(12.dp)
+    val Medium: ContinuousRoundedRectangle = ContinuousRoundedRectangle(12.dp)
 
     /** Large sized corner shape */
-    val Large: RoundedRectangle = RoundedRectangle(16.dp)
+    val Large: ContinuousRoundedRectangle = ContinuousRoundedRectangle(16.dp)
 
     /** Extra large sized corner shape */
-    val ExtraLarge: RoundedRectangle = RoundedRectangle(24.dp)
+    val ExtraLarge: ContinuousRoundedRectangle = ContinuousRoundedRectangle(24.dp)
 }

--- a/hig-native/src/commonMain/kotlin/zone/ien/hig/CupertinoDropdownMenuNative.kt
+++ b/hig-native/src/commonMain/kotlin/zone/ien/hig/CupertinoDropdownMenuNative.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import com.kyant.backdrop.Backdrop
 

--- a/hig-native/src/iosMain/kotlin/zone/ien/hig/CupertinoDropdownMenuNative.ios.kt
+++ b/hig-native/src/iosMain/kotlin/zone/ien/hig/CupertinoDropdownMenuNative.ios.kt
@@ -33,7 +33,6 @@ import platform.UIKit.UIContextMenuInteraction
 import platform.UIKit.UIContextMenuInteractionAnimatingProtocol
 import platform.UIKit.UIContextMenuInteractionDelegateProtocol
 import platform.UIKit.UIControlStateNormal
-import platform.UIKit.UIDevice
 import platform.UIKit.UIEvent
 import platform.UIKit.UIGestureRecognizer
 import platform.UIKit.UIMenu

--- a/hig-native/src/iosMain/kotlin/zone/ien/hig/util.ios.kt
+++ b/hig-native/src/iosMain/kotlin/zone/ien/hig/util.ios.kt
@@ -21,34 +21,31 @@
 package zone.ien.hig
 
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asSkiaBitmap
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.addressOf
-import kotlinx.cinterop.usePinned
-import org.jetbrains.skia.Data
-import org.jetbrains.skia.EncodedImageFormat
-import org.jetbrains.skia.Image
-import platform.Foundation.NSData
-import platform.Foundation.dataWithBytes
-import platform.UIKit.UIImage
-import platform.UIKit.UIUserInterfaceStyle
-import platform.UIKit.UIView
-import platform.UIKit.UIViewController
-import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.useContents
+import kotlinx.cinterop.usePinned
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGSizeMake
+import platform.Foundation.NSData
+import platform.Foundation.dataWithBytes
 import platform.UIKit.UIGraphicsBeginImageContextWithOptions
 import platform.UIKit.UIGraphicsEndImageContext
 import platform.UIKit.UIGraphicsGetImageFromCurrentImageContext
+import platform.UIKit.UIImage
 import platform.UIKit.UIImageRenderingMode
-import kotlin.math.roundToInt
+import platform.UIKit.UIUserInterfaceStyle
+import platform.UIKit.UIView
+import platform.UIKit.UIViewController
 
 internal fun UIViewController.applyTheme(dark: Boolean) {
     overrideUserInterfaceStyle =

--- a/hig-native/src/nonIosMain/kotlin/zone/ien/hig/CupertinoDropdownMenuNative.nonIos.kt
+++ b/hig-native/src/nonIosMain/kotlin/zone/ien/hig/CupertinoDropdownMenuNative.nonIos.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.window.PopupProperties
 import com.kyant.backdrop.Backdrop
-import zone.ien.hig.MenuSection
 import zone.ien.hig.theme.CupertinoColors
 import zone.ien.hig.theme.systemRed
 

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoBottomSheet.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoBottomSheet.kt
@@ -52,8 +52,6 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
-import com.kyant.shapes.copy
-import zone.ien.hig.theme.CupertinoTheme
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -62,6 +60,8 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
+import zone.ien.hig.CupertinoSheetState.Companion.Saver
+import zone.ien.hig.theme.CupertinoTheme
 import kotlin.jvm.JvmName
 
 /**
@@ -139,7 +139,7 @@ object CupertinoBottomSheetDefaults {
         @Composable
         @ReadOnlyComposable
         get() =
-            CupertinoTheme.shapes.large.copy(bottomStart = 0.dp, bottomEnd = 0.dp)
+            CupertinoTheme.shapes.large.copy(bottomStart = CornerSize(0.dp), bottomEnd = CornerSize(0.dp))
 
     @Composable
     fun DragHandle(

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoButton.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoButton.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import com.kyant.shapes.Capsule
+import com.kyant.capsule.ContinuousCapsule
 import zone.ien.hig.CupertinoButtonDefaults.filledButtonColors
 import zone.ien.hig.CupertinoButtonDefaults.plainButtonColors
 import zone.ien.hig.theme.CupertinoColors
@@ -82,12 +82,12 @@ enum class CupertinoButtonSize(
         contentPadding = PaddingValues(12.dp, 6.dp)
     ),
     Regular(
-        shape = { Capsule() },
+        shape = { ContinuousCapsule() },
         textStyle = { it.body },
         contentPadding = PaddingValues(16.dp, 10.dp)
     ),
     Large(
-        shape = { Capsule() },
+        shape = { ContinuousCapsule() },
         textStyle = { it.body },
         contentPadding = PaddingValues(24.dp, 18.dp)
     ),
@@ -136,7 +136,6 @@ fun CupertinoButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable RowScope.() -> Unit
 ) {
-
     val pressed by interactionSource.collectIsPressedAsState()
 
     val animatedAlpha by animateFloatAsState(

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoDialogs.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoDialogs.kt
@@ -56,7 +56,6 @@ import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -86,12 +85,12 @@ import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.kyant.capsule.ContinuousRoundedRectangle
-import zone.ien.hig.theme.isDark
 import zone.ien.hig.CupertinoDialogsTokens.AlertDialogTitleMessageSpacing
 import zone.ien.hig.section.CupertinoSectionTokens
 import zone.ien.hig.theme.BrightSeparatorColor
 import zone.ien.hig.theme.CupertinoColors
 import zone.ien.hig.theme.CupertinoTheme
+import zone.ien.hig.theme.isDark
 import zone.ien.hig.theme.systemBlue
 import zone.ien.hig.theme.systemGray7
 import zone.ien.hig.theme.systemRed

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoDialogs.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoDialogs.kt
@@ -85,8 +85,7 @@ import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.kyant.shapes.RoundedRectangle
-import com.kyant.shapes.UnevenRoundedRectangle
+import com.kyant.capsule.ContinuousRoundedRectangle
 import zone.ien.hig.theme.isDark
 import zone.ien.hig.CupertinoDialogsTokens.AlertDialogTitleMessageSpacing
 import zone.ien.hig.section.CupertinoSectionTokens
@@ -405,7 +404,7 @@ object CupertinoDialogsDefaults {
         @Composable
         get() = CupertinoColors.systemGray7
 
-    val Shape: RoundedRectangle
+    val Shape: ContinuousRoundedRectangle
         @Composable
         @ReadOnlyComposable
         get() = CupertinoTheme.shapes.medium

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoDropdownMenu.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoDropdownMenu.kt
@@ -92,8 +92,7 @@ import com.kyant.backdrop.drawBackdrop
 import com.kyant.backdrop.effects.blur
 import com.kyant.backdrop.effects.lens
 import com.kyant.backdrop.effects.vibrancy
-import com.kyant.shapes.RoundedRectangle
-import com.kyant.shapes.RoundedRectangularShape
+import com.kyant.capsule.ContinuousRoundedRectangle
 import zone.ien.hig.icons.CupertinoIcons
 import zone.ien.hig.icons.outlined.Checkmark
 import zone.ien.hig.section.CupertinoSectionDefaults
@@ -422,7 +421,7 @@ private fun CupertinoMenuScope.ActionWithoutPadding(
                 .heightIn(min = CupertinoSectionTokens.MinHeight)
                 .fillMaxWidth()
                 .padding(horizontal = 8.dp)
-                .clip(RoundedRectangle(24.dp))
+                .clip(ContinuousRoundedRectangle(24.dp))
                 .clickable(
                     enabled = enabled,
                     onClick = onClick,
@@ -569,7 +568,7 @@ private fun DropdownMenuContent(
                             effects = {
                                 vibrancy()
                                 blur(2.dp.toPx())
-                                if (shape is RoundedRectangularShape || shape is CornerBasedShape) {
+                                if (shape is ContinuousRoundedRectangle || shape is CornerBasedShape) {
                                     lens(12.dp.toPx(), 24.dp.toPx())
                                 }
                             },

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoFloatingActionButton.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoFloatingActionButton.kt
@@ -2,7 +2,6 @@ package zone.ien.hig
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoLiquidButton.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoLiquidButton.kt
@@ -43,7 +43,7 @@ import com.kyant.backdrop.drawBackdrop
 import com.kyant.backdrop.effects.blur
 import com.kyant.backdrop.effects.lens
 import com.kyant.backdrop.effects.vibrancy
-import com.kyant.shapes.RoundedRectangularShape
+import com.kyant.capsule.ContinuousRoundedRectangle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -171,7 +171,7 @@ fun CupertinoLiquidButton(
                     } else {
                         blur(2.dp.toPx())
                     }
-                    if (shape is RoundedRectangularShape || shape is CornerBasedShape) {
+                    if (shape is ContinuousRoundedRectangle || shape is CornerBasedShape) {
                         lens(12.dp.toPx(), 24.dp.toPx())
                     }
                 },

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoLiquidDialogs.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoLiquidDialogs.kt
@@ -75,7 +75,7 @@ import com.kyant.backdrop.effects.blur
 import com.kyant.backdrop.effects.colorControls
 import com.kyant.backdrop.effects.lens
 import com.kyant.backdrop.highlight.Highlight
-import com.kyant.shapes.RoundedRectangle
+import com.kyant.capsule.ContinuousRoundedRectangle
 import zone.ien.hig.section.CupertinoSectionTokens
 import zone.ien.hig.theme.BrightSeparatorColor
 import zone.ien.hig.theme.CupertinoColors
@@ -177,10 +177,10 @@ object CupertinoLiquidDialogsDefaults {
         @Composable
         get() = CupertinoColors.systemGray7
 
-    val Shape: RoundedRectangle
+    val Shape: ContinuousRoundedRectangle
         @Composable
         @ReadOnlyComposable
-        get() = RoundedRectangle(48.dp)
+        get() = ContinuousRoundedRectangle(48.dp)
 }
 @Composable
 private fun AnimatedDialog(

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoNavigationBar.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoNavigationBar.kt
@@ -24,7 +24,6 @@ package zone.ien.hig
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.spring
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -38,11 +37,9 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.Composable
@@ -98,7 +95,6 @@ import kotlinx.coroutines.launch
 import zone.ien.hig.theme.CupertinoTheme
 import zone.ien.hig.utils.DampedDragAnimation
 import zone.ien.hig.utils.InteractiveHighlight
-import zone.ien.hig.utils.rememberDefaultBackdrop
 import kotlin.math.abs
 import kotlin.math.sign
 

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoNavigationBar.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoNavigationBar.kt
@@ -91,7 +91,7 @@ import com.kyant.backdrop.effects.vibrancy
 import com.kyant.backdrop.highlight.Highlight
 import com.kyant.backdrop.shadow.InnerShadow
 import com.kyant.backdrop.shadow.Shadow
-import com.kyant.shapes.Capsule
+import com.kyant.capsule.ContinuousCapsule
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
@@ -266,7 +266,7 @@ fun CupertinoNavigationBar(
                         }
                         .drawBackdrop(
                             backdrop = backdrop,
-                            shape = { Capsule() },
+                            shape = { ContinuousCapsule() },
                             effects = {
                                 vibrancy()
                                 blur(2.dp.toPx())
@@ -307,7 +307,7 @@ fun CupertinoNavigationBar(
                             }
                             .drawBackdrop(
                                 backdrop = backdrop,
-                                shape = { Capsule() },
+                                shape = { ContinuousCapsule() },
                                 effects = {
                                     val progress = dampedDragAnimation.pressProgress
                                     vibrancy()
@@ -349,7 +349,7 @@ fun CupertinoNavigationBar(
                         .then(dampedDragAnimation.modifier)
                         .drawBackdrop(
                             backdrop = rememberCombinedBackdrop(backdrop, tabsBackdrop),
-                            shape = { Capsule() },
+                            shape = { ContinuousCapsule() },
                             effects = {
                                 val progress = dampedDragAnimation.pressProgress
                                 lens(
@@ -415,7 +415,7 @@ fun RowScope.CupertinoNavigationBarItem(
         verticalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterVertically),
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
-            .clip(Capsule())
+            .clip(ContinuousCapsule())
             .clickable(
                 enabled = enabled,
                 interactionSource = interactionSource,

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoPicker.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoPicker.kt
@@ -37,7 +37,6 @@ import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListLayoutInfo
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoPicker.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoPicker.kt
@@ -75,8 +75,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastFirstOrNull
-import com.kyant.shapes.RoundedRectangle
-import com.kyant.shapes.UnevenRoundedRectangle
+import com.kyant.capsule.ContinuousRoundedRectangle
 import zone.ien.hig.theme.CupertinoTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -510,7 +509,7 @@ internal object CupertinoPickerTokens {
             horizontal = 10.dp,
         )
 
-    val IndicatorShape: RoundedRectangle
+    val IndicatorShape: ContinuousRoundedRectangle
         @Composable get() = CupertinoTheme.shapes.small
 }
 

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoSlider.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoSlider.kt
@@ -74,7 +74,7 @@ import com.kyant.backdrop.effects.lens
 import com.kyant.backdrop.highlight.Highlight
 import com.kyant.backdrop.shadow.InnerShadow
 import com.kyant.backdrop.shadow.Shadow
-import com.kyant.shapes.Capsule
+import com.kyant.capsule.ContinuousCapsule
 import kotlinx.coroutines.flow.collectLatest
 import zone.ien.hig.theme.CupertinoColors
 import zone.ien.hig.theme.CupertinoTheme
@@ -1252,7 +1252,7 @@ internal object SliderTokens {
     val ThumbInnerElevation = 4.dp
     val ThumbWidth = 40.0.dp
     val ThumbHeight = 24.0.dp
-    val ThumbShape = Capsule()
+    val ThumbShape = ContinuousCapsule()
     val InactiveTrackHeight = 6.0.dp
     val TickMarksContainerSize = 1.5.dp
 }

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoSlider.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoSlider.kt
@@ -67,7 +67,6 @@ import com.kyant.backdrop.backdrops.layerBackdrop
 import com.kyant.backdrop.backdrops.rememberBackdrop
 import com.kyant.backdrop.backdrops.rememberCombinedBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
-import zone.ien.hig.utils.rememberDefaultBackdrop
 import com.kyant.backdrop.drawBackdrop
 import com.kyant.backdrop.effects.blur
 import com.kyant.backdrop.effects.lens

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoSwitch.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoSwitch.kt
@@ -72,7 +72,7 @@ import com.kyant.backdrop.effects.lens
 import com.kyant.backdrop.highlight.Highlight
 import com.kyant.backdrop.shadow.InnerShadow
 import com.kyant.backdrop.shadow.Shadow
-import com.kyant.shapes.Capsule
+import com.kyant.capsule.ContinuousCapsule
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
 import zone.ien.hig.theme.CupertinoColors
@@ -189,7 +189,7 @@ fun CupertinoSwitch(
         Box(
             Modifier
                 .layerBackdrop(trackBackdrop)
-                .clip(Capsule())
+                .clip(ContinuousCapsule())
                 .drawBehind {
                     val fraction = dampedDragAnimation.value
                     drawRect(lerp(uncheckedTrackColor, checkedTrackColor, fraction))
@@ -223,7 +223,7 @@ fun CupertinoSwitch(
                             }
                         }
                     ),
-                    shape = { Capsule() },
+                    shape = { ContinuousCapsule() },
                     effects = {
                         val progress = dampedDragAnimation.pressProgress
                         blur(8.dp.toPx() * (1f - progress))

--- a/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoTextField.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/CupertinoTextField.kt
@@ -46,7 +46,6 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.TextObfuscationMode
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.foundation.text.selection.TextSelectionColors
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable

--- a/hig/src/commonMain/kotlin/zone/ien/hig/Luminance.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/Luminance.kt
@@ -3,8 +3,6 @@ package zone.ien.hig
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toArgb
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 expect fun ImageBitmap.scale(width: Int, height: Int): ImageBitmap
 expect fun ImageBitmap.crop(x: Int, y: Int, width: Int, height: Int): ImageBitmap

--- a/hig/src/commonMain/kotlin/zone/ien/hig/section/CupertinoSectionDefaults.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/section/CupertinoSectionDefaults.kt
@@ -36,8 +36,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CornerBasedShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -55,9 +53,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.kyant.capsule.ContinuousRoundedRectangle
-import zone.ien.hig.LocalContentColor
 import zone.ien.hig.CupertinoIcon
 import zone.ien.hig.CupertinoIconDefaults
+import zone.ien.hig.LocalContentColor
 import zone.ien.hig.copy
 import zone.ien.hig.icons.CupertinoIcons
 import zone.ien.hig.icons.filled.XmarkCircle

--- a/hig/src/commonMain/kotlin/zone/ien/hig/section/CupertinoSectionDefaults.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/section/CupertinoSectionDefaults.kt
@@ -54,8 +54,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import com.kyant.shapes.RoundedRectangle
-import com.kyant.shapes.UnevenRoundedRectangle
+import com.kyant.capsule.ContinuousRoundedRectangle
 import zone.ien.hig.LocalContentColor
 import zone.ien.hig.CupertinoIcon
 import zone.ien.hig.CupertinoIconDefaults
@@ -107,9 +106,9 @@ object CupertinoSectionDefaults {
 
     @Composable
     @ReadOnlyComposable
-    fun shape(style: SectionStyle = LocalSectionStyle.current): RoundedRectangle =
+    fun shape(style: SectionStyle = LocalSectionStyle.current): ContinuousRoundedRectangle =
         if (style.grouped && style.inset) CupertinoTheme.shapes.extraLarge
-        else RoundedRectangle(0.dp)
+        else ContinuousRoundedRectangle(0.dp)
 
     @Composable
     @ReadOnlyComposable

--- a/hig/src/commonMain/kotlin/zone/ien/hig/section/LazyListSection.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/section/LazyListSection.kt
@@ -35,7 +35,6 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.foundation.shape.CornerSize
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier

--- a/hig/src/commonMain/kotlin/zone/ien/hig/section/LazySectionScope.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/section/LazySectionScope.kt
@@ -90,7 +90,6 @@ import zone.ien.hig.icons.outlined.ChevronUp
 import zone.ien.hig.theme.CupertinoTheme
 import zone.ien.hig.toStringWithLeadingZero
 import zone.ien.hig.defaultLocale
-import zone.ien.hig.enableNativeInput
 
 @Stable
 sealed interface LazySectionScope {

--- a/hig/src/commonMain/kotlin/zone/ien/hig/section/Section.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/section/Section.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -36,8 +35,7 @@ import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.util.fastSumBy
-import com.kyant.shapes.RoundedRectangle
-import com.kyant.shapes.UnevenRoundedRectangle
+import com.kyant.capsule.ContinuousRoundedRectangle
 import zone.ien.hig.CupertinoHorizontalDivider
 import zone.ien.hig.CupertinoSurface
 import zone.ien.hig.ExperimentalCupertinoApi
@@ -72,7 +70,7 @@ fun CupertinoSection(
     state: SectionState = rememberSectionState(canCollapse = true),
     enterTransition: EnterTransition = CupertinoSectionDefaults.EnterTransition,
     exitTransition: ExitTransition = CupertinoSectionDefaults.ExitTransition,
-    shape: RoundedRectangle = CupertinoSectionDefaults.shape(style),
+    shape: ContinuousRoundedRectangle = CupertinoSectionDefaults.shape(style),
     color: Color =
         if (style.grouped) {
             CupertinoSectionDefaults.Color

--- a/hig/src/commonMain/kotlin/zone/ien/hig/section/SectionScope.kt
+++ b/hig/src/commonMain/kotlin/zone/ien/hig/section/SectionScope.kt
@@ -60,7 +60,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import zone.ien.hig.LocalContentColor
 import zone.ien.hig.CupertinoButtonTokens
 import zone.ien.hig.CupertinoDatePickerDefaults
 import zone.ien.hig.CupertinoDatePickerState
@@ -73,16 +72,16 @@ import zone.ien.hig.CupertinoTextFieldColors
 import zone.ien.hig.CupertinoTextFieldDefaults
 import zone.ien.hig.CupertinoTimePickerState
 import zone.ien.hig.ExperimentalCupertinoApi
+import zone.ien.hig.LocalContentColor
 import zone.ien.hig.ProvideTextStyle
 import zone.ien.hig.copy
 import zone.ien.hig.cupertinoTween
+import zone.ien.hig.defaultLocale
 import zone.ien.hig.icons.CupertinoIcons
 import zone.ien.hig.icons.outlined.ChevronDown
 import zone.ien.hig.icons.outlined.ChevronUp
 import zone.ien.hig.theme.CupertinoTheme
 import zone.ien.hig.toStringWithLeadingZero
-import zone.ien.hig.defaultLocale
-import zone.ien.hig.enableNativeInput
 
 @Stable
 internal object SectionScopeImpl: SectionScope

--- a/hig/src/iosMain/kotlin/zone/ien/hig/CupertinoTextField.ios.kt
+++ b/hig/src/iosMain/kotlin/zone/ien/hig/CupertinoTextField.ios.kt
@@ -20,7 +20,6 @@ package zone.ien.hig
 
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.text.input.PlatformImeOptions
 
 /**
  * Enables native input for keyboard options on iOS.

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1783,7 +1783,16 @@ streamroller@^3.1.5:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1801,7 +1810,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2036,7 +2052,16 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ pluginManagement {
         google()
         gradlePluginPortal()
         mavenCentral()
-//        mavenLocal()
+        mavenLocal()
     }
 }
 
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-//        mavenLocal()
+        mavenLocal()
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ pluginManagement {
         google()
         gradlePluginPortal()
         mavenCentral()
-        mavenLocal()
+//        mavenLocal()
     }
 }
 
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        mavenLocal()
+//        mavenLocal()
     }
 }
 


### PR DESCRIPTION
## 요약
Gradle, Kotlin, Compose 등 핵심 의존성을 최신 버전으로 업데이트하고, `com.kyant.shapes` 라이브러리가 `com.kyant.capsule`로 변경됨에 따라 Shapes 관련 API를 마이그레이션했습니다.

## 주요 변경사항
- **의존성 업데이트**: AGP 9.1.1, Kotlin 2.4.10, Compose Plugin 1.11.1, Gradle 9.5.1 및 lifecycle, datetime, material-kolor, koin 등 주요 라이브러리 버전 업
- **Capsule 라이브러리 마이그레이션**: `com.kyant.shapes` → `com.kyant.capsule` group 변경 대응 (`ContinuousRoundedRectangle`, `ContinuousCapsule`로 대체)
- **Android SDK 버전 업**: compileSdk / targetSdk 36 → 37
- **라이브러리 버전 업**: lib-version-name 1.1.0 → 1.2.0
- **BottomSheet shape copy API 수정**: `CornerSize(0.dp)` 명시적 전달로 API 변경 대응
- **settings.gradle.kts**: mavenLocal 저장소 주석 해제

## 확인 사항
- capsule 라이브러리의 새로운 groupId(`zone.ien.capsule`)와 artifactId(`capsule`)가 정상 resolve되는지 확인 필요
- Compose 1.11.1 및 Kotlin 2.4.10과의 호환성 확인
- BottomSheet, Section 등 shape 변경된 컴포넌트 시각적 회귀 테스트 필요

## 영향 범위
- **전체 모듈**: 의존성 업데이트로 인한 빌드 환경 변화
- **UI 컴포넌트**: 모든 CupertinoShape 사용 컴포넌트 (Button, Switch, Slider, NavigationBar, BottomSheet, Section, Picker, Dialogs, DropdownMenu)
- **Shapes API**: `RoundedRectangle` → `ContinuousRoundedRectangle`, `Capsule` → `ContinuousCapsule` 타입 변경